### PR TITLE
Remove duplicate declaration of `url_to_file`

### DIFF
--- a/src/palimpzest/constants.py
+++ b/src/palimpzest/constants.py
@@ -59,17 +59,6 @@ class Cardinality(str, Enum):
     ONE_TO_ONE = "one-to-one"
     ONE_TO_MANY = "one-to-many"
 
-    @classmethod
-    def _missing_(cls, value):
-        if value:
-            normalized_value = "".join([x for x in value if x.isalpha()]).lower()
-            for member in cls:
-                normalized_member = "".join([x for x in member if x.isalpha()]).lower()
-                if normalized_member == normalized_value:
-                    return member
-        return cls.ONE_TO_ONE
-
-
 IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff"]
 PDF_EXTENSIONS = [".pdf"]
 XLS_EXTENSIONS = [".xls", ".xlsx"]

--- a/src/palimpzest/constants.py
+++ b/src/palimpzest/constants.py
@@ -59,6 +59,17 @@ class Cardinality(str, Enum):
     ONE_TO_ONE = "one-to-one"
     ONE_TO_MANY = "one-to-many"
 
+    @classmethod
+    def _missing_(cls, value):
+        if value:
+            normalized_value = "".join([x for x in value if x.isalpha()]).lower()
+            for member in cls:
+                normalized_member = "".join([x for x in member if x.isalpha()]).lower()
+                if normalized_member == normalized_value:
+                    return member
+        return cls.ONE_TO_ONE
+
+
 IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff"]
 PDF_EXTENSIONS = [".pdf"]
 XLS_EXTENSIONS = [".xls", ".xlsx"]

--- a/src/palimpzest/utils/udfs.py
+++ b/src/palimpzest/utils/udfs.py
@@ -86,16 +86,3 @@ def xls_to_tables(candidate):
         records.append(dr)
 
     return records
-
-
-def url_to_file(candidate):
-    """Function used to convert a DataRecord instance of URL to a File DataRecord."""
-    candidate.filename = candidate.url.split("/")[-1]
-    candidate.timestamp = datetime.now().isoformat()
-    try:
-        contents = requests.get(candidate.url).content
-    except Exception as e:
-        print(f"Error fetching URL {candidate.url}: {e}")
-        contents = b""
-    candidate.contents = contents
-    return [candidate]


### PR DESCRIPTION
Codebase cleanup:

- Removed the `url_to_file` function, which converted a URL in a `DataRecord` instance to a file. THIS WAS A DUPLICATE. The function exists as is in the file still.