### PR TITLE
Add MOA Image Base Prompts; Fix Configuration Issues

### DIFF
--- a/demos/image-demo.py
+++ b/demos/image-demo.py
@@ -50,7 +50,6 @@ if __name__ == "__main__":
     )
     data_record_collection = plan.run(config)
 
-    print("Obtained records", data_record_collection.data_records)
     imgs, breeds = [], []
     for record in data_record_collection:
         print("Trying to open ", record.filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "palimpzest"
-version = "0.6.2"
+version = "0.6.3"
 description = "Palimpzest is a system which enables anyone to process AI-powered analytical queries simply by defining them in a declarative language"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/palimpzest/prompts/prompt_factory.py
+++ b/src/palimpzest/prompts/prompt_factory.py
@@ -92,6 +92,7 @@ class PromptFactory:
         PromptStrategy.COT_QA_IMAGE_CRITIC: None,
         PromptStrategy.COT_QA_IMAGE_REFINE: None,
         PromptStrategy.COT_MOA_PROPOSER: COT_MOA_PROPOSER_BASE_SYSTEM_PROMPT,
+        PromptStrategy.COT_MOA_PROPOSER_IMAGE: COT_MOA_PROPOSER_BASE_SYSTEM_PROMPT,
         PromptStrategy.COT_MOA_AGG: COT_MOA_AGG_BASE_SYSTEM_PROMPT,
     }
     BASE_USER_PROMPT_MAP = {
@@ -104,6 +105,7 @@ class PromptFactory:
         PromptStrategy.COT_QA_IMAGE_CRITIC: BASE_CRITIQUE_PROMPT,
         PromptStrategy.COT_QA_IMAGE_REFINE: BASE_REFINEMENT_PROMPT,
         PromptStrategy.COT_MOA_PROPOSER: COT_MOA_PROPOSER_BASE_USER_PROMPT,
+        PromptStrategy.COT_MOA_PROPOSER_IMAGE: COT_MOA_PROPOSER_BASE_USER_PROMPT,
         PromptStrategy.COT_MOA_AGG: COT_MOA_AGG_BASE_USER_PROMPT,
     }
 

--- a/src/palimpzest/query/optimizer/optimizer.py
+++ b/src/palimpzest/query/optimizer/optimizer.py
@@ -219,6 +219,9 @@ class Optimizer:
             allow_conventional_query=self.allow_conventional_query,
             allow_code_synth=self.allow_code_synth,
             allow_token_reduction=self.allow_token_reduction,
+            allow_rag_reduction=self.allow_rag_reduction,
+            allow_mixtures=self.allow_mixtures,
+            allow_critic=self.allow_critic,
             optimization_strategy_type=self.optimization_strategy_type,
             use_final_op_quality=self.use_final_op_quality,
         )

--- a/src/palimpzest/query/processor/query_processor_factory.py
+++ b/src/palimpzest/query/processor/query_processor_factory.py
@@ -123,6 +123,9 @@ class QueryProcessorFactory:
             allow_conventional_query=config.allow_conventional_query,
             allow_code_synth=config.allow_code_synth,
             allow_token_reduction=config.allow_token_reduction,
+            allow_rag_reduction=config.allow_rag_reduction,
+            allow_mixtures=config.allow_mixtures,
+            allow_critic=config.allow_critic,
             optimization_strategy_type=optimizer_strategy,
             use_final_op_quality=config.use_final_op_quality
         )


### PR DESCRIPTION
Small hotfixes to:
1. patch errors in generating prompts for MOA proposers with image inputs
2. pass through configuration flags for RAG, MOA, and Critic convert ops