### PR TITLE
Limit the Scope of Logging within the Optimizer

### DIFF
--- a/src/palimpzest/query/optimizer/optimizer.py
+++ b/src/palimpzest/query/optimizer/optimizer.py
@@ -475,7 +475,6 @@ class Optimizer:
             self.tasks_stack.extend(new_tasks)
 
         logger.debug(f"Done searching optimization space for group_id: {group_id}")
-        logger.debug(f"Tasks stack: {self.tasks_stack}")
 
     def optimize(self, query_plan: Dataset, policy: Policy | None = None) -> list[PhysicalPlan]:
         """

--- a/src/palimpzest/query/optimizer/rules.py
+++ b/src/palimpzest/query/optimizer/rules.py
@@ -92,9 +92,6 @@ class PushDownFilter(TransformationRule):
         logical_expression: LogicalExpression, groups: dict[int, Group], expressions: dict[int, Expression], **kwargs
     ) -> tuple[set[LogicalExpression], set[Group]]:
         logger.debug(f"Substituting PushDownFilter for {logical_expression}")
-        # logger.debug(f"Groups: {groups}")
-        # logger.debug(f"Expressions: {expressions}")
-        # logger.debug(f"kwargs: {kwargs}")
 
         # initialize the sets of new logical expressions and groups to be returned
         new_logical_expressions, new_groups = set(), set()
@@ -203,8 +200,7 @@ class PushDownFilter(TransformationRule):
                 new_logical_expressions.add(new_expr)
 
         logger.debug(f"Done substituting PushDownFilter for {logical_expression}")
-        # logger.debug(f"New logical expressions: {new_logical_expressions}")
-        # logger.debug(f"New groups: {new_groups}")
+
         return new_logical_expressions, new_groups
 
 
@@ -230,7 +226,6 @@ class NonLLMConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting NonLLMConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -257,7 +252,6 @@ class NonLLMConvertRule(ImplementationRule):
 
         deduped_physical_expressions = set([expression])
         logger.debug(f"Done substituting NonLLMConvertRule for {logical_expression}")
-        # logger.debug(f"Expression: {deduped_physical_expressions}")
 
         return deduped_physical_expressions
 
@@ -283,7 +277,6 @@ class LLMConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting LLMConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -353,7 +346,7 @@ class LLMConvertRule(ImplementationRule):
 
         deduped_physical_expressions = set(physical_expressions)
         logger.debug(f"Done substituting LLMConvertRule for {logical_expression}")
-        # logger.debug(f"Physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -400,7 +393,6 @@ class TokenReducedConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting TokenReducedConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -448,7 +440,7 @@ class TokenReducedConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting TokenReducedConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -499,7 +491,6 @@ class CodeSynthesisConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting CodeSynthesisConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -531,7 +522,7 @@ class CodeSynthesisConvertRule(ImplementationRule):
         )
         deduped_physical_expressions = set([expression])
         logger.debug(f"Done substituting CodeSynthesisConvertRule for {logical_expression}")
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -565,7 +556,6 @@ class RAGConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting RAGConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -615,7 +605,7 @@ class RAGConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting RAGConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 class MixtureOfAgentsConvertRule(ImplementationRule):
@@ -635,7 +625,6 @@ class MixtureOfAgentsConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting MixtureOfAgentsConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -707,7 +696,7 @@ class MixtureOfAgentsConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting MixtureOfAgentsConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 class CriticAndRefineConvertRule(ImplementationRule):
@@ -725,7 +714,6 @@ class CriticAndRefineConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting CriticAndRefineConvertRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -806,7 +794,7 @@ class CriticAndRefineConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting CriticAndRefineConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -827,7 +815,6 @@ class RetrieveRule(ImplementationRule):
         cls, logical_expression: LogicalExpression, **physical_op_params
     ) -> set[PhysicalExpression]:
         logger.debug(f"Substituting RetrieveRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -860,7 +847,7 @@ class RetrieveRule(ImplementationRule):
 
         logger.debug(f"Done substituting RetrieveRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -881,7 +868,6 @@ class NonLLMFilterRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting NonLLMFilterRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -904,7 +890,7 @@ class NonLLMFilterRule(ImplementationRule):
         )
         logger.debug(f"Done substituting NonLLMFilterRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -925,7 +911,6 @@ class LLMFilterRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting LLMFilterRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -991,7 +976,7 @@ class LLMFilterRule(ImplementationRule):
 
         logger.debug(f"Done substituting LLMFilterRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -1009,7 +994,6 @@ class AggregateRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting AggregateRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -1040,7 +1024,7 @@ class AggregateRule(ImplementationRule):
 
         logger.debug(f"Done substituting AggregateRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions
 
 
@@ -1068,7 +1052,6 @@ class BasicSubstitutionRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting BasicSubstitutionRule for {logical_expression}")
-        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -1093,5 +1076,5 @@ class BasicSubstitutionRule(ImplementationRule):
         
         logger.debug(f"Done substituting BasicSubstitutionRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+
         return deduped_physical_expressions

--- a/src/palimpzest/query/optimizer/rules.py
+++ b/src/palimpzest/query/optimizer/rules.py
@@ -92,9 +92,9 @@ class PushDownFilter(TransformationRule):
         logical_expression: LogicalExpression, groups: dict[int, Group], expressions: dict[int, Expression], **kwargs
     ) -> tuple[set[LogicalExpression], set[Group]]:
         logger.debug(f"Substituting PushDownFilter for {logical_expression}")
-        logger.debug(f"Groups: {groups}")
-        logger.debug(f"Expressions: {expressions}")
-        logger.debug(f"kwargs: {kwargs}")
+        # logger.debug(f"Groups: {groups}")
+        # logger.debug(f"Expressions: {expressions}")
+        # logger.debug(f"kwargs: {kwargs}")
 
         # initialize the sets of new logical expressions and groups to be returned
         new_logical_expressions, new_groups = set(), set()
@@ -203,8 +203,8 @@ class PushDownFilter(TransformationRule):
                 new_logical_expressions.add(new_expr)
 
         logger.debug(f"Done substituting PushDownFilter for {logical_expression}")
-        logger.debug(f"New logical expressions: {new_logical_expressions}")
-        logger.debug(f"New groups: {new_groups}")
+        # logger.debug(f"New logical expressions: {new_logical_expressions}")
+        # logger.debug(f"New groups: {new_groups}")
         return new_logical_expressions, new_groups
 
 
@@ -230,7 +230,7 @@ class NonLLMConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting NonLLMConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -257,7 +257,7 @@ class NonLLMConvertRule(ImplementationRule):
 
         deduped_physical_expressions = set([expression])
         logger.debug(f"Done substituting NonLLMConvertRule for {logical_expression}")
-        logger.debug(f"Expression: {deduped_physical_expressions}")
+        # logger.debug(f"Expression: {deduped_physical_expressions}")
 
         return deduped_physical_expressions
 
@@ -283,7 +283,7 @@ class LLMConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting LLMConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -353,7 +353,7 @@ class LLMConvertRule(ImplementationRule):
 
         deduped_physical_expressions = set(physical_expressions)
         logger.debug(f"Done substituting LLMConvertRule for {logical_expression}")
-        logger.debug(f"Physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -400,7 +400,7 @@ class TokenReducedConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting TokenReducedConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -448,7 +448,7 @@ class TokenReducedConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting TokenReducedConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -499,7 +499,7 @@ class CodeSynthesisConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting CodeSynthesisConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -531,7 +531,7 @@ class CodeSynthesisConvertRule(ImplementationRule):
         )
         deduped_physical_expressions = set([expression])
         logger.debug(f"Done substituting CodeSynthesisConvertRule for {logical_expression}")
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -565,7 +565,7 @@ class RAGConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting RAGConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -615,7 +615,7 @@ class RAGConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting RAGConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 class MixtureOfAgentsConvertRule(ImplementationRule):
@@ -635,7 +635,7 @@ class MixtureOfAgentsConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting MixtureOfAgentsConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -707,7 +707,7 @@ class MixtureOfAgentsConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting MixtureOfAgentsConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 class CriticAndRefineConvertRule(ImplementationRule):
@@ -725,7 +725,7 @@ class CriticAndRefineConvertRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting CriticAndRefineConvertRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -806,7 +806,7 @@ class CriticAndRefineConvertRule(ImplementationRule):
 
         logger.debug(f"Done substituting CriticAndRefineConvertRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -827,7 +827,7 @@ class RetrieveRule(ImplementationRule):
         cls, logical_expression: LogicalExpression, **physical_op_params
     ) -> set[PhysicalExpression]:
         logger.debug(f"Substituting RetrieveRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
 
@@ -860,7 +860,7 @@ class RetrieveRule(ImplementationRule):
 
         logger.debug(f"Done substituting RetrieveRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -881,7 +881,7 @@ class NonLLMFilterRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting NonLLMFilterRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -904,7 +904,7 @@ class NonLLMFilterRule(ImplementationRule):
         )
         logger.debug(f"Done substituting NonLLMFilterRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -925,7 +925,7 @@ class LLMFilterRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting LLMFilterRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -991,7 +991,7 @@ class LLMFilterRule(ImplementationRule):
 
         logger.debug(f"Done substituting LLMFilterRule for {logical_expression}")
         deduped_physical_expressions = set(physical_expressions)
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -1009,7 +1009,7 @@ class AggregateRule(ImplementationRule):
     @staticmethod
     def substitute(logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting AggregateRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -1040,7 +1040,7 @@ class AggregateRule(ImplementationRule):
 
         logger.debug(f"Done substituting AggregateRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions
 
 
@@ -1068,7 +1068,7 @@ class BasicSubstitutionRule(ImplementationRule):
     @classmethod
     def substitute(cls, logical_expression: LogicalExpression, **physical_op_params) -> set[PhysicalExpression]:
         logger.debug(f"Substituting BasicSubstitutionRule for {logical_expression}")
-        logger.debug(f"Physical op params: {physical_op_params}")
+        # logger.debug(f"Physical op params: {physical_op_params}")
 
         logical_op = logical_expression.operator
         op_kwargs = logical_op.get_logical_op_params()
@@ -1093,5 +1093,5 @@ class BasicSubstitutionRule(ImplementationRule):
         
         logger.debug(f"Done substituting BasicSubstitutionRule for {logical_expression}")
         deduped_physical_expressions = set([expression])
-        logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
+        # logger.debug(f"Deduped physical expressions: {deduped_physical_expressions}")
         return deduped_physical_expressions

--- a/src/palimpzest/query/optimizer/tasks.py
+++ b/src/palimpzest/query/optimizer/tasks.py
@@ -65,7 +65,7 @@ class OptimizeGroup(Task):
             new_tasks.append(task)
 
         logger.debug(f"Done optimizing group {self.group_id}")
-        logger.debug(f"New tasks: {new_tasks}")
+        logger.debug(f"New tasks: {len(new_tasks)}")
         return new_tasks
 
 
@@ -102,7 +102,7 @@ class ExpandGroup(Task):
         group.set_explored()
 
         logger.debug(f"Done expanding group {self.group_id}")
-        logger.debug(f"New tasks: {new_tasks}")
+        logger.debug(f"New tasks: {len(new_tasks)}")
         return new_tasks
 
 
@@ -146,7 +146,7 @@ class OptimizeLogicalExpression(Task):
             new_tasks.append(apply_rule_task)
 
         logger.debug(f"Done optimizing logical expression {self.logical_expression}")
-        logger.debug(f"New tasks: {new_tasks}")
+        logger.debug(f"New tasks: {len(new_tasks)}")
         return new_tasks
 
 
@@ -250,7 +250,7 @@ class ApplyRule(Task):
         self.logical_expression.add_applied_rule(self.rule)
 
         logger.debug(f"Done applying rule {self.rule} to logical expression {self.logical_expression}")
-        logger.debug(f"New tasks: {new_tasks}")
+        logger.debug(f"New tasks: {len(new_tasks)}")
         return new_tasks
 
 

--- a/src/palimpzest/tools/logger.py
+++ b/src/palimpzest/tools/logger.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -7,7 +8,16 @@ from pathlib import Path
 def setup_logger(name):
     pz_logger = PZLogger()
     logger = pz_logger.get_logger(name)
-    logger.setLevel(logging.DEBUG)
+    log_level = os.getenv("PZ_LOG_LEVEL", "ERROR").upper()
+    if log_level == "DEBUG":
+        logger.setLevel(logging.DEBUG)
+    elif log_level == "INFO":
+        logger.setLevel(logging.INFO)
+    elif log_level == "WARNING":
+        logger.setLevel(logging.WARNING)
+    else:
+        logger.setLevel(logging.ERROR)
+
     logger.info(f"Initialized logger for {name}")
     return logger
 

--- a/tests/pytest/test_optimizer.py
+++ b/tests/pytest/test_optimizer.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from palimpzest.constants import Cardinality, Model
@@ -267,6 +269,8 @@ class TestOptimizer:
         assert isinstance(physical_plan[5], LLMFilter)  # ImageRealEstateListing(attractive)
 
     def test_seven_filters(self, enron_eval_tiny, email_schema, opt_strategy):
+        start_time = time.time()
+
         plan = Dataset(enron_eval_tiny)
         plan = plan.sem_add_columns(email_schema)
         plan = plan.sem_filter("filter1", depends_on=["contents"])
@@ -301,6 +305,7 @@ class TestOptimizer:
         assert isinstance(physical_plan[7], LLMFilter)
         assert isinstance(physical_plan[8], CodeSynthesisConvert)
 
+        assert time.time() - start_time < 2.0, "Optimizer should complete this test within 2 seconds; if it's failed, something has caused a regression, and you should ping Matthew Russo (mdrusso@mit.edu)"
 
 class MockSampleBasedCostModel:
     """


### PR DESCRIPTION
Some of the logging within the optimizer can lead to massive log files (> 1GB) when running our current unit tests. Additionally, the default setting of `DEBUG` level logging is causing a regression / slow-down in optimizer performance.

This PR aims to address these issues by:

1. Removing log messages within the Optimizer which are flooding the log file with massive Python objects that are hard to interpret
2. Defaulting to an `ERROR` log level
3. Making it possible to set the log level via code

@sivaprasadsudhir may tackle 3.