### PR TITLE
Add Pneuma-Palimpzest Integration Demo

### DIFF
--- a/demos/pneuma-demo.py
+++ b/demos/pneuma-demo.py
@@ -79,9 +79,6 @@ def parse_arguments():
 
 def build_pneuma_query(pneuma: Pneuma, dataset: QuestionDataReader, k: int):
     questions = pz.Dataset(dataset)
-    questions = questions.sem_add_columns(
-        question_dataset_cols, desc="Extract the question"
-    )
 
     def extract_table_content(df: pd.DataFrame):
         columns = " | ".join(df.columns)

--- a/demos/pneuma-demo.py
+++ b/demos/pneuma-demo.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+import os
+
+import palimpzest as pz
+import pandas as pd
+
+from pneuma import Pneuma
+
+question_dataset_cols = [
+    {
+        "name": "question",
+        "type": str,
+        "desc": "The question related to the contents of some table(s).",
+    }
+]
+
+output_cols = [
+    {
+        "name": "answer",
+        "type": str,
+        "desc": "Output the answer to the `question` based on the contents in `relevant_tables`; output unknown if the contents cannot answer the question.",
+    }
+]
+
+
+class QuestionDataReader(pz.DataReader):
+    def __init__(self, questions_dataset_path: str, num_questions_to_process: int):
+        super().__init__(question_dataset_cols)
+
+        # `questions_dataset_path` is the path to the file containing the questions which is expected to be a jsonl file.
+        # Each line in the file is a JSON object with an "id" and a "question" field.
+
+        self.questions_dataset_path = questions_dataset_path
+        self.num_questions_to_process = num_questions_to_process
+
+        with open(questions_dataset_path) as f:
+            entries = [json.loads(line) for line in f]
+            entries = entries[: min(num_questions_to_process, len(entries))]
+            self.questions = [entry["question"] for entry in entries]
+            self.ids = [entry["id"] for entry in entries]
+
+    def __len__(self):
+        return len(self.questions)
+
+    def __getitem__(self, idx: int):
+        # get question
+        question = self.questions[idx]
+
+        # construct and return dictionary with field(s)
+        return {"question": question}
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Run Pneuma demo")
+    parser.add_argument(
+        "--questions-dataset-path",
+        type=str,
+        help="Path to the questions dataset",
+        default="data_src/questions.jsonl",
+    )
+    parser.add_argument(
+        "--num-questions-to-process",
+        type=int,
+        help="Number of questions from the dataset to process",
+        default=5,
+    )
+    parser.add_argument(
+        "--out-path", type=str, help="Path to the output file of Pneuma", default="pneuma-demo"
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        help="Number of relevant documents to retrieve from the index; Pneuma returns <= k tables (each table may be associated with multiple documents)",
+        default=5,
+    )
+    return parser.parse_args()
+
+
+def build_pneuma_query(pneuma: Pneuma, dataset: QuestionDataReader, k: int):
+    questions = pz.Dataset(dataset)
+    questions = questions.sem_add_columns(
+        question_dataset_cols, desc="Extract the question"
+    )
+
+    def extract_table_content(df: pd.DataFrame):
+        columns = " | ".join(df.columns)
+        rows = "\n".join(" | ".join(map(str, row[1:])) for row in df.itertuples())
+        return f"{columns}\n{rows}"
+
+    def search_func(index: Pneuma, query: str, k: int):
+        response = index.query_index(
+            index_name="demo_index",
+            queries=query,
+            k=k,
+            n=5,
+            alpha=0.5,
+        )
+        response = json.loads(response)
+        retrieved_tables = response["data"][0]["retrieved_tables"]
+
+        relevant_tables: list[str] = []
+        for table in retrieved_tables:
+            table_content = extract_table_content(pd.read_csv(table))
+            relevant_tables.append(table_content)
+        return relevant_tables
+
+    questions_and_relevant_files = questions.retrieve(
+        index=pneuma,
+        search_func=search_func,
+        search_attr="question",
+        output_attr="relevant_tables",
+        output_attr_desc="Most relevant tables to the `question`",
+        k=k,
+    )
+    output = questions_and_relevant_files.sem_add_columns(output_cols)
+    return output
+
+
+def main():
+    if os.getenv("OPENAI_API_KEY") is None and os.getenv("TOGETHER_API_KEY") is None:
+        print("WARNING: Both OPENAI_API_KEY and TOGETHER_API_KEY are unset")
+
+    args = parse_arguments()
+
+    # Create a data reader for the question dataset (in this demo ChEMBL)
+    dataset = QuestionDataReader(
+        questions_dataset_path=args.questions_dataset_path,
+        num_questions_to_process=args.num_questions_to_process,
+    )
+
+    # Load the index
+    pneuma = Pneuma(
+        out_path=args.out_path,
+        llm_path="Qwen/Qwen2.5-7B-Instruct",  # Change to a smaller LLM if necessary
+        embed_path="BAAI/bge-base-en-v1.5",
+    )
+    pneuma.setup()
+
+    # Use OpenAI models (gpt-4o-mini & text-embedding-3-small) if the index was
+    # generated using OpenAI models
+    # pneuma = Pneuma(
+    #     out_path=args.out_path,
+    #     openai_api_key=os.environ['OPENAI_API_KEY'],
+    #     use_local_model=False,
+    # )
+
+    # Build and run some query
+    query = build_pneuma_query(pneuma, dataset, args.k)
+    data_record_collection = query.run(pz.QueryProcessorConfig())
+    print(data_record_collection.to_df())
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/pneuma-gen-index.py
+++ b/demos/pneuma-gen-index.py
@@ -1,0 +1,118 @@
+import json
+import os
+import tarfile
+import urllib.request
+
+import requests
+
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
+from pneuma import Pneuma
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, "data_src")
+
+
+def post_process_dataset(dataset_path: str):
+    for table in os.listdir(dataset_path):
+        os.rename(
+            f"{dataset_path}/{table}", f"{dataset_path}/{table.split('_SEP_')[1]}"
+        )
+    print("Dataset processed")
+
+
+def extract_tar(tar_name: str, extract_path="."):
+    try:
+        with tarfile.open(tar_name, "r") as tar:
+            tar.extractall(path=extract_path)
+            print(f"Extracted all files to '{extract_path}'")
+        os.remove(tar_name)
+        print(f"Removed the tar file: '{tar_name}'")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+def download_chembl():
+    if "pneuma_chembl_10K" in os.listdir(DATA_DIR):
+        print("Dataset already downloaded")
+        return
+
+    tar_name = "pneuma_chembl_10K.tar"
+    urllib.request.urlretrieve(
+        f"https://storage.googleapis.com/pneuma_open/{tar_name}",
+        filename=os.path.join(DATA_DIR, tar_name),
+    )
+    extract_tar(os.path.join(DATA_DIR, tar_name), DATA_DIR)
+    post_process_dataset(os.path.join(DATA_DIR, tar_name[:-4]))
+
+
+def download_questions():
+    if "questions.jsonl" in os.listdir(DATA_DIR):
+        print("Questions already downloaded")
+        return
+
+    URL = "https://docs.google.com/uc?export=download"
+    FILE_ID = "1vdddvHeHdNgAquceBEO4dK-LMyLUtPv1"
+
+    session = requests.Session()
+    response = session.get(URL, params={"id": FILE_ID}, stream=True)
+
+    for key, value in response.cookies.items():
+        if key.startswith("download_warning"):
+            response = session.get(
+                URL, params={"id": FILE_ID, "confirm": value}, stream=True
+            )
+            break
+
+    with open(os.path.join(DATA_DIR, "questions.jsonl"), "wb") as f:
+        for chunk in response.iter_content(32768):
+            if chunk:
+                f.write(chunk)
+
+    print(f"Questions downloaded")
+
+
+def main():
+    # Step 1: Download dataset & questions
+    if "data_src" not in os.listdir(SCRIPT_DIR):
+        os.mkdir(DATA_DIR)
+    download_chembl()
+    download_questions()
+
+    # Step 2: Initialize Pneuma
+    out_path = "pneuma-demo"
+    pneuma = Pneuma(
+        out_path=out_path,
+        llm_path="Qwen/Qwen2.5-7B-Instruct",  # Change to a smaller LLM if necessary
+        embed_path="BAAI/bge-base-en-v1.5",
+    )
+
+    # Alternative: Use OpenAI models (gpt-4o-mini & text-embedding-3-small); may take longer
+    # pneuma = Pneuma(
+    #     out_path=out_path,
+    #     openai_api_key=os.environ['OPENAI_API_KEY'],
+    #     use_local_model=False,
+    # )
+
+    pneuma.setup()
+
+    # Step 3: Register dataset
+    data_path = "data_src/pneuma_chembl_10K"
+    response = pneuma.add_tables(path=data_path, creator="pneuma_pz_demo")
+    response = json.loads(response)
+    print(response)
+
+    # Step 4: Summarize dataset
+    response = pneuma.summarize()
+    response = json.loads(response)
+    print(response)
+
+    # Step 5: Generate index
+    response = pneuma.generate_index(index_name="demo_index")
+    response = json.loads(response)
+    print(response)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pneuma-Palimpzest Integration Demo

Pneuma is an LLM-based data discovery system for tabular data. Given a natural-language question, Pneuma retrieves the most relevant table(s) for the question. However, in some cases, users may want direct answers instead of just the raw data. This is where Palimpzest (PZ) comes in. It builds on Pneuma's retrieval step by answering questions using the relevant tables Pneuma provides.

As an illustration, suppose a chemist has research questions about molecular properties. Instead of manually searching through large datasets, they need a system that can both retrieve relevant tables and extract insights from them. This demo showcases how Pneuma and PZ work together in such a scenario.

For this demo, we use a subset of the [ChEMBL dataset](https://www.ebi.ac.uk/chembl/), which is a database of bioactive molecules with drug-like properties. The questions are directly related to the dataset’s contents, such as _“What fifth-level classification is associated with molecules that have the registration number 1609148?”_ Pneuma first indexes ChEMBL using `pneuma-gen-index.py`, which also handles downloading the dataset and the associated questions (`questions.jsonl`). Then, in `pneuma-demo.py`, Pneuma retrieves relevant tables, and PZ generates answers based on them. This demonstrates the end-to-end pipeline, where Pneuma discovers relevant tables, and PZ transforms retrieved tables into direct, actionable insights.