### PR TITLE
Update Python requirement and fix dependency clash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/build/*
 docs/source/generated/*
 dist/*
 .vscode/*
+.idea/*
 .chroma
 .chroma-biodex
 .chroma-mmqa
@@ -31,6 +32,7 @@ testdata/*.tar.gz
 
 # virtual environment(s)
 venv/
+uv.lock
 
 # tmp
 testdata/maildir/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "palimpzest"
 version = "0.8.2"
 description = "Palimpzest is a system which enables anyone to process AI-powered analytical queries simply by defining them in a declarative language"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["relational", "optimization", "llm", "AI programming", "extraction", "tools", "document", "search", "integration"]
 authors = [
     {name="MIT DSG Semantic Management Lab", email="michjc@csail.mit.edu"},
@@ -53,7 +53,6 @@ docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.3",
     "mkdocstrings-python>=1.15.0",
-    "mkdocs-material[imaging]",
 ]
 vllm = [
     "vllm>=0.10.1.1",


### PR DESCRIPTION
The project currently claims to support python > 3.8, but some of our dependencies require >= 3.10. Also, mkdocs-material[imaging] (pillow >= 10.2, < 11)is clashing with together (pillow > 11.3.0). Since we are moving away from mkdocs, I am removing that dependency to make sure we have a clean build (tested with uv).