### PR TITLE
Bugfix: mock method to increment costs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "palimpzest"
-version = "1.5.1"
+version = "1.5.2"
 description = "Palimpzest is a system which enables anyone to process AI-powered analytical queries simply by defining them in a declarative language"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/palimpzest/utils/progress.py
+++ b/src/palimpzest/utils/progress.py
@@ -172,6 +172,9 @@ class MockProgressManager(ProgressManager):
     def finish(self):
         pass
 
+    def incr_overall_progress_cost(self, cost_delta: float):
+        pass
+ 
 class PZProgressManager(ProgressManager):
     """Progress manager for command line interface using rich"""
     


### PR DESCRIPTION
Fixed a bug when using Abacus optimizer without progress bar.
Bug was triggered since MAB Execution strategy calls:
`self.progress_manager.incr_overall_progress_cost(val_gen_stats.cost_per_record)`
But when `progress` is False in the runtime configuration, the `MockProgressManager` does not expose that function.
This fix is simple enough but maybe in future `incr_overall_progress_cost` may be defined by the `ProgressManager` class. 

