### PR TITLE
Added policy parametrization from kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "palimpzest"
-version = "1.5.2"
+version = "1.5.3"
 description = "Palimpzest is a system which enables anyone to process AI-powered analytical queries simply by defining them in a declarative language"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/palimpzest/core/data/dataset.py
+++ b/src/palimpzest/core/data/dataset.py
@@ -717,6 +717,8 @@ class Dataset:
         if policy is not None:
             kwargs["policy"] = policy
 
+        config.policy = policy
+
         # construct unique logical op ids for all operators in this dataset
         self._generate_unique_logical_op_ids()
 

--- a/src/palimpzest/core/data/dataset.py
+++ b/src/palimpzest/core/data/dataset.py
@@ -716,8 +716,7 @@ class Dataset:
         policy = construct_policy_from_kwargs(**kwargs)
         if policy is not None:
             kwargs["policy"] = policy
-
-        config.policy = policy
+            config.policy = policy
 
         # construct unique logical op ids for all operators in this dataset
         self._generate_unique_logical_op_ids()


### PR DESCRIPTION
Fixing a minor bug where when calling the `optimize_and_run()` method with a policy kwarg, e.g., `dataset.optimize_and_run(max_quality=True, validator=vdt, config=pz_config)`, the resulting code was parsing the policy but not adding it to the `config` object. 
Added the following line after the call to `policy = construct_policy_from_kwargs(**kwargs)`:

`config.policy = policy`
